### PR TITLE
Forma de pegar TaxVat modificada

### DIFF
--- a/app/code/local/Gamuza/Itaushopline/Model/Standard.php
+++ b/app/code/local/Gamuza/Itaushopline/Model/Standard.php
@@ -98,7 +98,7 @@ public function order (Varien_Object $payment, $amount)
     $obsadd1 = $this->_getStoreConfig ('settings/obsadd1');
     $obsadd2 = $this->_getStoreConfig ('settings/obsadd2');
     $obsadd3 = $this->_getStoreConfig ('settings/obsadd3');
-    $tax_vat = $order->getCustomer()->getTaxvat ();
+    $tax_vat = $order->getCustomerTaxvat();
     $address = $quote->getBillingAddress();
     $name = $address->getName ();
     list ($street1, $street2) = $this->_getSplittedStreet ($address, $store_id);


### PR DESCRIPTION
Fazendo essa alteração, comprar como visitante funciona normalmente, pois não é preciso pegar a instância de Customer para pegar o TaxVat, ele pega direto do modelo do pedido.
